### PR TITLE
Fix ContentRow render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
+## <next>
+* Small fix in `Content.Row` render
+
 ## 2.5.2
 * Fix peer dependency version requirement
 

--- a/src/content/columns/content-row.component.jsx
+++ b/src/content/columns/content-row.component.jsx
@@ -29,16 +29,19 @@ class ContentRow extends React.PureComponent {
         }}
         id={id}
       >
-        {React.Children.map(children, (child, i) => {
-          // If it's a regular DOM node
-          if (typeof child.type === 'string') return child;
+        {React.Children.map(children, (child, i) => { // eslint-disable-line consistent-return
+          // Child may be null
+          if (child) {
+            // If it's a regular DOM node
+            if (typeof child.type === 'string') return child;
 
-          // If it's a React component (in most cases Content.Column)
-          return React.cloneElement(child, {
-            parent: this.colContainer,
-            isLastItem: i === children.length - 1 && children.length !== 1,
-            columnCount: children.length,
-          });
+            // If it's a React component (in most cases Content.Column)
+            return React.cloneElement(child, {
+              parent: this.colContainer,
+              isLastItem: i === children.length - 1 && children.length !== 1,
+              columnCount: children.length,
+            });
+          }
         })}
       </Row>
     );


### PR DESCRIPTION
Before the fix it wasn't possible to do e.g. this: 
`<Content.Row>
{showIfTrue && <Content.Column</Content.Column>}
</Content.Row>`

