### PR TITLE
Relocate ReadonlyRow's ID attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
+## <next>
+* Move `ReadonlyRow`'s id attribute directly to `span` element
 
 ## 3.0.0
 * Theme: Refactored colors object (contains breaking changes)

--- a/src/content/input-row/content-readonly-row.component.jsx
+++ b/src/content/input-row/content-readonly-row.component.jsx
@@ -5,8 +5,8 @@ import InputRow from './content-input-row.component';
 const ContentReadonlyRow = ({
   label, value, normalize, asColumn, id, ...rest
 }) => (
-  <InputRow id={id} asColumn={asColumn} label={label} showError={false} {...rest}>
-    <span>
+  <InputRow asColumn={asColumn} label={label} showError={false} {...rest}>
+    <span id={id}>
       {normalize ? normalize(value) : value}
     </span>
   </InputRow>


### PR DESCRIPTION
* Move `ReadonlyRow`'s id attribute directly to `span` element
